### PR TITLE
add mission param dictionnary to vfleet

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,6 @@ Click here to [![badge](https://img.shields.io/badge/launch-Pangeo%20binder-579A
 ***
 This software is developped by:
 <div>
-<img src="http://www.argo-france.fr/wp-content/uploads/2019/10/Argo-logo_banner-color.png" width="200"/>
+<img src="https://www.argo-france.fr/wp-content/uploads/2019/10/Argo-logo_banner-color.png" width="200"/>
 <img src="https://www.umr-lops.fr/var/storage/images/_aliases/logo_main/medias-ifremer/medias-lops/logos/logo-lops-2/1459683-4-fre-FR/Logo-LOPS-2.png" width="70"/>
 </div>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,10 +30,17 @@ Then define a virtual Argo float deployment plan with arrays for latitude, longi
     lat = np.linspace(30, 38, nfloats)
     lon = np.full_like(lat, -70)
     dpt = np.linspace(1.0, 1.0, nfloats) #1m depth
-    tim = np.full_like(lat, np.datetime64('2019-01-01'))
+    tim = np.array(['2019-01-01' for i in range(nfloats)],dtype='datetime64')
+
+    # Mission parameters
+    parking_depth = 1000. #in m
+    profile_depth = 2000.
+    vertical_speed = 0.09 #in m/s
+    cycle_duration = 10. # in days
+    mission = {'parking_depth':parking_depth, 'profile_depth':profile_depth, 'vertical_speed':vertical_speed, 'cycle_duration':cycle_duration}
     
     # Create your fleet:
-    VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=depth, time=ti, vfield=tfield)
+    VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=depth, time=ti, vfield=tfield, mission=mission)
 ```
 
 You can easily checkout your plan:

--- a/examples/plot_run.ipynb
+++ b/examples/plot_run.ipynb
@@ -214,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/try_it-CustomPlans.ipynb
+++ b/examples/try_it-CustomPlans.ipynb
@@ -146,10 +146,18 @@
     "lon = np.random.uniform(lon0-Lx/2, lon0+Lx/2, size=nfloats)\n",
     "lat = np.random.uniform(lat0-Ly/2, lat0+Ly/2, size=nfloats)\n",
     "dpt = np.linspace(1.0, 1.0, nfloats) #1m depth\n",
-    "tim = np.full_like(lat, np.datetime64('2019-01-01'))\n",
+    "tim = np.array(['2019-01-01' for i in range(nfloats)],dtype='datetime64')\n",
+    "\n",
+    "# Mission parameters\n",
+    "parking_depth = 1000. #in m\n",
+    "profile_depth = 2000.\n",
+    "vertical_speed = 0.09 #in m/s\n",
+    "cycle_duration = 10. # in days\n",
+    "\n",
+    "mission = {'parking_depth':parking_depth, 'profile_depth':profile_depth, 'vertical_speed':vertical_speed, 'cycle_duration':cycle_duration}\n",
     "\n",
     "# DEFINE THE FLOAT OBJECT\n",
-    "VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=dpt, time=tim, vfield=VELfield)"
+    "VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=dpt, time=tim, vfield=VELfield, mission=mission)"
    ]
   },
   {
@@ -172,10 +180,18 @@
     "lat = np.linspace(30, 38, nfloats)\n",
     "lon = np.full_like(lat, -60)\n",
     "dpt = np.linspace(1.0, 1.0, nfloats) #1m depth\n",
-    "tim = np.full_like(lat, np.datetime64('2019-01-01'))\n",
+    "tim = np.array(['2019-01-01' for i in range(nfloats)],dtype='datetime64')\n",
+    "\n",
+    "# Mission parameters\n",
+    "parking_depth = 1000. #in m\n",
+    "profile_depth = 2000.\n",
+    "vertical_speed = 0.09 #in m/s\n",
+    "cycle_duration = 10. # in days\n",
+    "\n",
+    "mission = {'parking_depth':parking_depth, 'profile_depth':profile_depth, 'vertical_speed':vertical_speed, 'cycle_duration':cycle_duration}\n",
     "\n",
     "# DEFINE THE FLOAT OBJECT\n",
-    "VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=dpt, time=tim, vfield=VELfield)"
+    "VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=dpt, time=tim, vfield=VELfield, mission=mission)"
    ]
   },
   {
@@ -198,7 +214,14 @@
     "# lon = np.full_like(tim, -60)\n",
     "# lat = np.full_like(tim, 36)\n",
     "# dpt = np.full_like(tim, 1)\n",
-    "# VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=dpt, time=tim, vfield=VELfield)"
+    "## Mission parameters\n",
+    "#parking_depth = 1000. #in m\n",
+    "#profile_depth = 2000.\n",
+    "#vertical_speed = 0.09 #in m/s\n",
+    "#cycle_duration = 10. # in days\n",
+    "\n",
+    "#mission = {'parking_depth':parking_depth, 'profile_depth':profile_depth, 'vertical_speed':vertical_speed, 'cycle_duration':cycle_duration}\n",
+    "# VFleet = vaf.virtualfleet(lat=lat, lon=lon, depth=dpt, time=tim, vfield=VELfield, mission=mission)"
    ]
   },
   {
@@ -516,7 +539,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/try_it-RealPlan.ipynb
+++ b/examples/try_it-RealPlan.ipynb
@@ -1677,7 +1677,7 @@
     "    ds_traj.append(ds.where(ds['PLATFORM_NUMBER']==wmo, drop=1).drop_vars(['N_LEVELS', 'N_PROF']))\n",
     "ds_traj = xr.concat(ds_traj, dim='N_POINTS')\n",
     "ds_traj = ds_traj.argo.point2profile()\n",
-    "ds_traj"
+    "print(ds_traj)"
    ]
   },
   {
@@ -1686,7 +1686,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "VFleet = vaf.virtualfleet(lat=ds_plan['LATITUDE'], lon=ds_plan['LONGITUDE'], depth=ds_plan['PRES'], time=ds_plan['TIME'], vfield=VELfield)"
+    "# Mission parameters\n",
+    "parking_depth = 1000. #in m\n",
+    "profile_depth = 2000.\n",
+    "vertical_speed = 0.09 #in m/s\n",
+    "cycle_duration = 10. # in days\n",
+    "mission = {'parking_depth':parking_depth, 'profile_depth':profile_depth, 'vertical_speed':vertical_speed, 'cycle_duration':cycle_duration}\n",
+    "\n",
+    "VFleet = vaf.virtualfleet(lat=ds_plan['LATITUDE'], lon=ds_plan['LONGITUDE'], depth=ds_plan['PRES'], time=ds_plan['TIME'], vfield=VELfield, mission=mission)"
    ]
   },
   {
@@ -2090,7 +2097,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/virtualargofleet/virtualargofleet.py
+++ b/virtualargofleet/virtualargofleet.py
@@ -160,14 +160,19 @@ class virtualfleet:
         duration = kwargs['duration']
         dt_run = kwargs['dt_run']
         dt_out = kwargs['dt_out']
-        output_file = kwargs['output_file']
-        self.run_params = {'duration': duration, 'dt_run':dt_run, 'dt_out': dt_out, 'output_file': output_file}
+        output_path = kwargs['output_file']
+        self.run_params = {'duration': duration, 'dt_run':dt_run, 'dt_out': dt_out, 'output_file': output_path}
 
+        output_file = self.pset.ParticleFile(name=output_path, outputdt=timedelta(hours=dt_out))
         # Now execute the kernels for X days, saving data every Y minutes
         self.pset.execute(self.kernels, 
                           runtime = timedelta(days = duration), 
                           dt = timedelta(hours = dt_run), 
-                          output_file = self.pset.ParticleFile(name = output_file,outputdt = timedelta(hours = dt_out)),
-                          recovery = {ErrorCode.ErrorOutOfBounds: DeleteParticle})                        
+                          output_file = output_file,
+                          recovery = {ErrorCode.ErrorOutOfBounds: DeleteParticle})    
+        output_file.export()
+        output_file.close()
+
+
     
         

--- a/virtualargofleet/virtualargofleet.py
+++ b/virtualargofleet/virtualargofleet.py
@@ -12,77 +12,86 @@ from datetime import timedelta
 import numpy as np
 import xarray as xr
 
+
 class ArgoParticle(JITParticle):
-        # Phase of cycle: init_descend = 0, drift = 1, profile_descend = 2, profile_ascend = 3, transmit = 4
-        cycle_phase = Variable('cycle_phase', dtype = np.int32, initial = 0.)
-        cycle_age = Variable('cycle_age', dtype = np.float32, initial = 0.)
-        drift_age = Variable('drift_age', dtype = np.float32, initial = 0.)       
-        
-# Define the new Kernel that mimics Argo vertical movement
-def ArgoVerticalMovement(particle, fieldset, time):    
+    """ Internal class used by parcels to add variables to particle kernel    
+    """
+    # Phase of cycle: init_descend = 0, drift = 1, profile_descend = 2, profile_ascend = 3, transmit = 4
+    cycle_phase = Variable('cycle_phase', dtype=np.int32, initial=0.)
+    cycle_age = Variable('cycle_age', dtype=np.float32, initial=0.)
+    drift_age = Variable('drift_age', dtype=np.float32, initial=0.)
 
-        driftdepth = fieldset.parking_depth
-        maxdepth = fieldset.profile_depth
-        mindepth = 20
-        vertical_speed = fieldset.v_speed  # in m/s
-        cycletime = fieldset.cycle_duration * 86400  # in s
+def ArgoVerticalMovement(particle, fieldset, time):
+    """ This is the kernel definition that mimics the argo float behaviour.
+        It can only have (particle, fieldset, time) as arguments. So missions parameters are passed as constants through the fieldset.         
+    """
+    driftdepth = fieldset.parking_depth
+    maxdepth = fieldset.profile_depth
+    mindepth = 20 #not too close to the surface so that particle doesn't go above it
+    vertical_speed = fieldset.v_speed  # in m/s
+    cycletime = fieldset.cycle_duration * 86400  # in s
 
-        # Compute drifting time so that the cycletime is respected:
-        transit = (driftdepth - mindepth) / vertical_speed  # Time to descent to parking (mindepth to driftdepth at vertical_speed)
-        transit += (maxdepth - driftdepth) / vertical_speed  # Time to descent to profile depth (driftdepth to maxdepth at vertical_speed)
-        transit += (maxdepth - mindepth) / vertical_speed  # Time to ascent (maxdepth to mindepth at vertical_speed)
-        drifttime = cycletime - transit
+    # Compute drifting time so that the cycletime is respected:
+    # Time to descent to parking (mindepth to driftdepth at vertical_speed)
+    transit = (driftdepth - mindepth) / vertical_speed
+    # Time to descent to profile depth (driftdepth to maxdepth at vertical_speed)
+    transit += (maxdepth - driftdepth) / vertical_speed
+    # Time to ascent (maxdepth to mindepth at vertical_speed)
+    transit += (maxdepth - mindepth) / vertical_speed
+    drifttime = cycletime - transit
 
-        if particle.cycle_phase ==  0:
-            # Phase 0: Sinking with vertical_speed until depth is driftdepth
-            particle.depth +=  vertical_speed * particle.dt
-            if particle.depth >=  driftdepth:
-                particle.cycle_phase = 1
+    if particle.cycle_phase == 0:
+       # Phase 0: Sinking with vertical_speed until depth is driftdepth
+       particle.depth += vertical_speed * particle.dt
+       if particle.depth >= driftdepth:
+           particle.cycle_phase = 1
 
-        elif particle.cycle_phase ==  1:
-            # Phase 1: Drifting at depth for drifttime seconds
-            particle.drift_age +=  particle.dt
-            if particle.drift_age >=  drifttime:
-                particle.drift_age = 0  # reset drift_age for next cycle
-                particle.cycle_phase = 2
+    elif particle.cycle_phase == 1:
+        # Phase 1: Drifting at depth for drifttime seconds
+        particle.drift_age += particle.dt
+        if particle.drift_age >= drifttime:
+            particle.drift_age = 0  # reset drift_age for next cycle
+            particle.cycle_phase = 2
 
-        elif particle.cycle_phase ==  2:
-            # Phase 2: Sinking further to maxdepth
-            particle.depth +=  vertical_speed * particle.dt
-            if particle.depth >=  maxdepth:
-                particle.cycle_phase = 3
+    elif particle.cycle_phase == 2:
+        # Phase 2: Sinking further to maxdepth
+        particle.depth += vertical_speed * particle.dt
+        if particle.depth >= maxdepth:
+            particle.cycle_phase = 3
 
-        elif particle.cycle_phase ==  3:
-            # Phase 3: Rising with vertical_speed until at surface
-            particle.depth -=  vertical_speed * particle.dt
-            if particle.depth <=  mindepth:
-                particle.depth = mindepth
-                particle.cycle_phase = 4
+    elif particle.cycle_phase == 3:
+        # Phase 3: Rising with vertical_speed until at surface
+        particle.depth -= vertical_speed * particle.dt
+        if particle.depth <= mindepth:
+            particle.depth = mindepth
+            particle.cycle_phase = 4
 
-        elif particle.cycle_phase ==  4:
-            # Phase 4: Transmitting at surface until cycletime is reached
-            if particle.cycle_age >= cycletime:
-                particle.cycle_phase = 0
-                particle.cycle_age = 0         
-               
-        particle.cycle_age +=  particle.dt  # update cycle_age    
-                
+    elif particle.cycle_phase == 4:
+        # Phase 4: Transmitting at surface until cycletime is reached
+        if particle.cycle_age >= cycletime:
+            particle.cycle_phase = 0
+            particle.cycle_age = 0
+
+    particle.cycle_age += particle.dt  # update cycle_age
+
 # define recovery for OutOfBounds Error
-def DeleteParticle(particle, fieldset, time):  # delete particles who run out of bounds.    
+# delete particles who run out of bounds.
+def DeleteParticle(particle, fieldset, time):
     print("Particle deleted on boundary")
     particle.delete()
-              
-def periodicBC(particle, fieldset, time):    
+
+def periodicBC(particle, fieldset, time):
     if particle.lon < fieldset.halo_west:
-        particle.lon +=  fieldset.halo_east - fieldset.halo_west
+        particle.lon += fieldset.halo_east - fieldset.halo_west
     elif particle.lon > fieldset.halo_east:
-        particle.lon -=  fieldset.halo_east - fieldset.halo_west
-  
+        particle.lon -= fieldset.halo_east - fieldset.halo_west
+
     if particle.lat < fieldset.halo_south:
-        particle.lat +=  fieldset.halo_north - fieldset.halo_south
+        particle.lat += fieldset.halo_north - fieldset.halo_south
     elif particle.lat > fieldset.halo_north:
-        particle.lat -=  fieldset.halo_north - fieldset.halo_south        
-        
+        particle.lat -= fieldset.halo_north - fieldset.halo_south
+
+
 class velocityfield:
     """
     USAGE :    
@@ -90,65 +99,72 @@ class velocityfield:
     var : dictionnary for variables 
     dim : dictionnary for dimensions lat,lon,depth,time
     isglobal : 1 if field is global, 0 otherwise
-    """         
-    def __init__(self,**kwargs):    
+    """
+
+    def __init__(self, **kwargs):
         #props
         self.field = kwargs['ds']
         self.var = kwargs['var']
         self.dim = kwargs['dim']
         self.isglobal = kwargs['isglobal']
         #define parcels fieldset
-        self.fieldset = FieldSet.from_netcdf(self.field, self.var, self.dim, allow_time_extrapolation = True)
-        if self.isglobal :
+        self.fieldset = FieldSet.from_netcdf(
+            self.field, self.var, self.dim, allow_time_extrapolation=True)
+        if self.isglobal:
             self.fieldset.add_constant('halo_west', fieldset.U.grid.lon[0])
             self.fieldset.add_constant('halo_east', fieldset.U.grid.lon[-1])
             self.fieldset.add_constant('halo_south', fieldset.U.grid.lat[0])
             self.fieldset.add_constant('halo_north', fieldset.U.grid.lat[-1])
-            self.fieldset.add_periodic_halo(zonal = True,meridional = True)
-          
+            self.fieldset.add_periodic_halo(zonal=True, meridional=True)
+
     def plot(self):
-        temp_pset = ParticleSet(fieldset = self.fieldset, pclass = ArgoParticle, lon = 0, lat = 0, depth = 0)
-        temp_pset.show(field = self.fieldset.U, with_particles = False)
+        temp_pset = ParticleSet(fieldset=self.fieldset, pclass=ArgoParticle, lon=0, lat=0, depth=0)
+        temp_pset.show(field=self.fieldset.U, with_particles=False)
         #temp_pset.show(field = self.fieldset.V,with_particles = False)
-        
+
+
 class virtualfleet:
     """
     USAGE:
     lat,lon,depth,time : numpy arrays describing initial set of floats
     vfield : velocityfield object
     mission : dictionnary {'parking_depth':parking_depth, 'profile_depth':profile_depth, 'vertical_speed':vertical_speed, 'cycle_duration':cycle_duration}
-    """    
-    def __init__(self,**kwargs):    
+    """
+
+    def __init__(self, **kwargs):
         #props
         self.lat = kwargs['lat']
         self.lon = kwargs['lon']
-        self.depth = kwargs['depth']        
-        self.time = kwargs['time']        
+        self.depth = kwargs['depth']
+        self.time = kwargs['time']
         vfield = kwargs['vfield']
         mission = kwargs['mission']
         #Pass mission parameters to simulation through fieldset
         vfield.fieldset.add_constant('parking_depth', mission['parking_depth'])
         vfield.fieldset.add_constant('profile_depth', mission['profile_depth'])
         vfield.fieldset.add_constant('v_speed', mission['vertical_speed'])
-        vfield.fieldset.add_constant('cycle_duration', mission['cycle_duration'])
-        
-        #define parcels particleset     
-        self.pset = ParticleSet(fieldset = vfield.fieldset, 
-                                pclass = ArgoParticle,
-                                lon = self.lon,
-                                lat = self.lat,
-                                depth = self.depth,
-                                time = self.time)        
+        vfield.fieldset.add_constant(
+            'cycle_duration', mission['cycle_duration'])
+
+        #define parcels particleset
+        self.pset = ParticleSet(fieldset=vfield.fieldset,
+                                pclass=ArgoParticle,
+                                lon=self.lon,
+                                lat=self.lat,
+                                depth=self.depth,
+                                time=self.time)
         if vfield.isglobal:
             # combine Argo vertical movement kernel with Advection kernel + boundaries
-            self.kernels = ArgoVerticalMovement + self.pset.Kernel(AdvectionRK4) + self.pset.Kernel(periodicBC) 
+            self.kernels = ArgoVerticalMovement + \
+                self.pset.Kernel(AdvectionRK4) + self.pset.Kernel(periodicBC)
         else:
-            self.kernels = ArgoVerticalMovement + self.pset.Kernel(AdvectionRK4)
-    
+            self.kernels = ArgoVerticalMovement + \
+                self.pset.Kernel(AdvectionRK4)
+
     def plotfloat(self):
         #using parcels psel builtin show function for now
         self.pset.show()
-            
+
     def simulate(self, **kwargs):
         """
         USAGE:
@@ -161,18 +177,16 @@ class virtualfleet:
         dt_run = kwargs['dt_run']
         dt_out = kwargs['dt_out']
         output_path = kwargs['output_file']
-        self.run_params = {'duration': duration, 'dt_run':dt_run, 'dt_out': dt_out, 'output_file': output_path}
+        self.run_params = {'duration': duration, 'dt_run': dt_run,
+                           'dt_out': dt_out, 'output_file': output_path}
 
-        output_file = self.pset.ParticleFile(name=output_path, outputdt=timedelta(hours=dt_out))
+        output_file = self.pset.ParticleFile(
+            name=output_path, outputdt=timedelta(hours=dt_out))
         # Now execute the kernels for X days, saving data every Y minutes
-        self.pset.execute(self.kernels, 
-                          runtime = timedelta(days = duration), 
-                          dt = timedelta(hours = dt_run), 
-                          output_file = output_file,
-                          recovery = {ErrorCode.ErrorOutOfBounds: DeleteParticle})    
+        self.pset.execute(self.kernels,
+                          runtime=timedelta(days=duration),
+                          dt=timedelta(hours=dt_run),
+                          output_file=output_file,
+                          recovery={ErrorCode.ErrorOutOfBounds: DeleteParticle})
         output_file.export()
         output_file.close()
-
-
-    
-        

--- a/virtualargofleet/virtualargofleet.py
+++ b/virtualargofleet/virtualargofleet.py
@@ -11,7 +11,7 @@ from parcels import FieldSet, ParticleSet, JITParticle, AdvectionRK4, ErrorCode,
 from datetime import timedelta
 import numpy as np
 import xarray as xr
-
+import os, tempfile
 
 class ArgoParticle(JITParticle):
     """ Internal class used by parcels to add variables to particle kernel    
@@ -177,6 +177,14 @@ class virtualfleet:
         dt_run = kwargs['dt_run']
         dt_out = kwargs['dt_out']
         output_path = kwargs['output_file']
+        if ((os.path.exists(output_path)) | (output_path=='')) :    
+            temp_name = next(tempfile._get_candidate_names())+'.nc'
+            while os.path.exists(temp_name):
+                temp_name = next(tempfile._get_candidate_names())+'.nc'                
+            output_path = temp_name        
+            print("Filename empty of file already exists, simulation will be saved in : " + output_path)
+        else:
+            print("Simulation will be saved in : " + output_path)                
         self.run_params = {'duration': duration, 'dt_run': dt_run,
                            'dt_out': dt_out, 'output_file': output_path}
 


### PR DESCRIPTION
I added this dictionary to the `virtualfleet` class initialisation : 
`mission = {'parking_depth':parking_depth, 'profile_depth':profile_depth, 'vertical_speed':vertical_speed, 'cycle_duration':cycle_duration}`

Parcels kernel function do not accept argument (other than `particle, fieldset, time`), or non-local variable. So I had to pass the parameters through the `fieldset` via the [fieldset.add_constant()](https://oceanparcels.org/gh-pages/html/#parcels.fieldset.FieldSet.add_constant) so parameters are accessible by the kernel.

If parameters are meant to change during the simulation (I know @gmaze want to test some stuff like that), I guess we would have to add another specific kernel for mission parameters management 