### PR TITLE
Prepare VirtualFleet for publication as a pypi package

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -69,13 +69,13 @@ jobs:
           ls -ltrh dist
 
       - name: Verify the built dist/wheel is valid
-#        if: github.event_name == 'push'
+        if: github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/VirtualFleet*.whl
 
       - name: Publish package to TestPyPI
-#        if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -72,7 +72,7 @@ jobs:
 #        if: github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
-          python -m pip install dist/Virtualfleet*.whl
+          python -m pip install dist/VirtualFleet*.whl
 
       - name: Publish package to TestPyPI
 #        if: github.event_name == 'push'

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -72,7 +72,7 @@ jobs:
 #        if: github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
-          python -m pip install dist/virtualfleet*.whl
+          python -m pip install dist/Virtualfleet*.whl
 
       - name: Publish package to TestPyPI
 #        if: github.event_name == 'push'
@@ -83,7 +83,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           verbose: true
 #          verify_metadata: false
-#          skip_existing: true
+          skip_existing: true
 
   upload-to-pypi:
     needs: test-built-dist

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -69,13 +69,13 @@ jobs:
           ls -ltrh dist
 
       - name: Verify the built dist/wheel is valid
-        if: github.event_name == 'push'
+#        if: github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/virtualfleet*.whl
 
       - name: Publish package to TestPyPI
-        if: github.event_name == 'push'
+#        if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,12 +1,12 @@
 name: Build and Upload to PyPI
 on:
-# release:
-#   types: [created, edited]
-#  push:
-#    branches:
-#      - master
-#   tags:
-#     - 'v*'
+  release:
+    types: [created, edited]
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,13 @@
 [options]
-packages = find:
+packages = find_namespace:
+package_dir =
+    = .
+include_package_data = True
 exclude = './binder, ./docs, ./.github, ./examples, ./local_work, ./__pycache__, ./.coveragerc'
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
-include_package_data = True
 
-[options.package_data]
-assets =
-    *.json
+[options.packages.find]
+where = virtualargofloat
 
 install_requires =
     numpy >= 1.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,10 @@ exclude = './binder, ./docs, ./.github, ./examples, ./local_work, ./__pycache__,
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
 
+[options.package_data]
+assets =
+    *.json
+
 install_requires =
     numpy >= 1.18
     pandas >= 1.1


### PR DESCRIPTION
We already have done some work in #16 but Parcels was not available on Pypi yet.
It is now (https://github.com/OceanParcels/parcels/pull/1163).

So we can move on to fully prepare VirtualFleet for publication as a pypi package