### PR TITLE
JSON schema for Argo Float Configuration

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -8,8 +8,8 @@ What's New
 |pypi dwn|
 
 
-Upcoming features
------------------
+Coming up next
+--------------
 
 - Virtual Argo float configuration manager :class:`FloatConfiguration` now uses a well documented `JSON schema <https://raw.githubusercontent.com/euroargodev/VirtualFleet/master/schemas/VF-ArgoFloat-Configuration.json>`_ to load/validate and save
 the set of parameters. (:pr:`29`) by `G. Maze <http://www.github.com/gmaze>`_.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -8,6 +8,12 @@ What's New
 |pypi dwn|
 
 
+Upcoming features
+-----------------
+
+- Virtual Argo float configuration manager :class:`FloatConfiguration` now uses a well documented `JSON schema <https://raw.githubusercontent.com/euroargodev/VirtualFleet/master/schemas/VF-ArgoFloat-Configuration.json>`_ to load/validate and save
+the set of parameters. (:pr:`29`) by `G. Maze <http://www.github.com/gmaze>`_.
+
 v0.4.0 (2 Feb. 2024)
 --------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,8 @@ dependencies:
   - lz4
   - libzip
   - nomkl
-#  - nbserverproxy
+  - jsonschema
+  - referencing
   - jupyter
   - jupyterlab>=0.35
   - jupyterlab_launcher

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -1,12 +1,16 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "VirtualFleet Argo Float configuration",
-  "description": "A set of meta-data documenting virtual Argo Float configuration to be used in a VirtualFleet simulation",
+  "description": "A set of data documenting a virtual Argo Float configuration to be used in a VirtualFleet simulation",
   "format_version": {
-    "const": "0.1"
+    "const": "2.0"
   },
-  "required": [ "created", "version", "name" ],
+  "required": [
+    "created",
+    "version",
+    "name",
+    "parameters"
+  ],
   "type": "object",
   "properties": {
     "created": {
@@ -22,79 +26,112 @@
       "description": "Internal shortname of the configuration parameter set. Used to load a configuration JSON file",
       "type": "string"
     },
-    "data": {
+    "parameters": {
       "description": "List of configuration parameters",
       "type": "array",
-      "allOf": [
-        { "contains": {
-          "type": "object",
-          "properties": {
-            "cycle_duration": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "integer"
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "description": {"type": "string"},
-                    "unit": {"type": "string"},
-                    "dtype": {"type": "string"},
-                    "teckkey": {"type": "string"}
-                  }
-                }
-              }
-            }
+      "oneOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/required_parameter"
           }
-        } },
-        { "contains": {
-          "type": "object",
-          "properties": {
-            "life_expectancy": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "integer"
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "description": {"type": "string"},
-                    "unit": {"type": "string"},
-                    "dtype": {"type": "string"},
-                    "teckkey": {"type": "string"}
-                  }
-                }
-              }
-            }
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/optional_parameter"
           }
-        } }
-      ],
-      "additionalItems": {
-        "anyOf": [
-          {"type": "object",
-          "properties": {
-            "area_cycle_duration": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "integer"
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "description": {"type": "string"},
-                    "unit": {"type": "string"},
-                    "dtype": {"type": "string"},
-                    "teckkey": {"type": "string"}
-                  }
-                }
-              }
-            }
-          }},
-          {}
-        ]
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "required_parameter": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "VirtualFleet Argo Float configuration required parameter",
+      "description": "A set of data documenting one parameter for a virtual Argo Float configuration",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": [
+            "cycle_duration",
+            "life_expectancy",
+            "parking_depth",
+            "profile_depth",
+            "vertical_speed"
+          ]
+        },
+        "value": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "meta": {
+          "$ref": "#/$defs/parameter_metadata"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "optional_parameter": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "VirtualFleet Argo Float configuration optional parameter",
+      "description": "A set of data documenting one parameter for a virtual Argo Float configuration",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": [
+            "area_cycle_duration",
+            "area_parking_depth",
+            "area_xmax",
+            "area_xmin",
+            "area_ymax",
+            "area_ymin"
+          ]
+        },
+        "value": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "meta": {
+          "$ref": "#/$defs/parameter_metadata"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "parameter_metadata": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "VirtualFleet Argo Float configuration parameter meta-data",
+      "required": [],
+      "type": "object",
+      "properties": {
+        "unit": {
+          "type": "string"
+        },
+        "dtype": {
+          "type": "string",
+          "enum": [
+            "float",
+            "int"
+          ]
+        },
+        "teckkey": {
+          "type": "string"
+        }
       }
     }
   }

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -82,7 +82,7 @@
     "optional_parameter": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "VirtualFleet Argo Float configuration optional parameter",
-      "description": "A set of data documenting one parameter for a virtual Argo Float configuration",
+      "description": "Set of data documenting one parameter for a virtual Argo Float configuration",
       "type": "object",
       "properties": {
         "name": {
@@ -116,7 +116,7 @@
     },
     "parameter_metadata": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "VirtualFleet Argo Float configuration parameter meta-data",
+      "title": "Set of meta-data documenting one parameter for a virtual Argo Float configuration",
       "required": [],
       "type": "object",
       "properties": {

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json",
   "title": "VirtualFleet Argo Float configuration",
   "description": "A set of data documenting a virtual Argo Float configuration to be used in a VirtualFleet simulation",
@@ -41,7 +41,6 @@
   },
   "$defs": {
     "parameter": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "VirtualFleet Argo Float configuration required parameter",
       "description": "A set of data documenting one parameter for a virtual Argo Float configuration",
       "type": "object",
@@ -81,7 +80,6 @@
       ]
     },
     "parameter_metadata": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Set of meta-data documenting one parameter for a virtual Argo Float configuration",
       "required": [],
       "type": "object",
@@ -101,5 +99,6 @@
         }
       }
     }
-  }
+  },
+  "version": 2
 }

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json",
+  "title": "VirtualFleet Argo Float configuration",
+  "description": "A set of meta-data documenting virtual Argo Float configuration to be used in a VirtualFleet simulation",
+  "format_version": {
+    "const": "0.1"
+  },
+  "required": [ "created", "version", "name" ],
+  "type": "object",
+  "properties": {
+    "created": {
+      "description": "UTC creation datetime of the configuration file",
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "description": "Version name of the configuration parameter set",
+      "type": "string"
+    },
+    "name": {
+      "description": "Internal shortname of the configuration parameter set. Used to load a configuration JSON file",
+      "type": "string"
+    },
+    "data": {
+      "description": "List of configuration parameters",
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ConfigParam.json"
+      },
+      "minItems": 5,
+      "uniqueItems": true
+    }
+  }
+}

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -30,22 +30,17 @@
     "parameters": {
       "description": "List of virtual Argo floats configuration parameters",
       "type": "array",
-      "oneOf": [
+      "allOf": [
         {
           "items": {
-            "$ref": "#/$defs/required_parameter"
-          }
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/optional_parameter"
+            "$ref": "#/$defs/parameter"
           }
         }
       ]
     }
   },
   "$defs": {
-    "required_parameter": {
+    "parameter": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "VirtualFleet Argo Float configuration required parameter",
       "description": "A set of data documenting one parameter for a virtual Argo Float configuration",
@@ -58,36 +53,7 @@
             "life_expectancy",
             "parking_depth",
             "profile_depth",
-            "vertical_speed"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "number"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "meta": {
-          "$ref": "#/$defs/parameter_metadata"
-        }
-      },
-      "required": [
-        "name",
-        "value"
-      ]
-    },
-    "optional_parameter": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "VirtualFleet Argo Float configuration optional parameter",
-      "description": "Set of data documenting one parameter for a virtual Argo Float configuration",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": [
+            "vertical_speed",
             "area_cycle_duration",
             "area_parking_depth",
             "area_xmax",

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -25,11 +25,77 @@
     "data": {
       "description": "List of configuration parameters",
       "type": "array",
-      "items": {
-        "$ref": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ConfigParam.json"
-      },
-      "minItems": 5,
-      "uniqueItems": true
+      "allOf": [
+        { "contains": {
+          "type": "object",
+          "properties": {
+            "cycle_duration": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "integer"
+                },
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "description": {"type": "string"},
+                    "unit": {"type": "string"},
+                    "dtype": {"type": "string"},
+                    "teckkey": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        } },
+        { "contains": {
+          "type": "object",
+          "properties": {
+            "life_expectancy": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "integer"
+                },
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "description": {"type": "string"},
+                    "unit": {"type": "string"},
+                    "dtype": {"type": "string"},
+                    "teckkey": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        } }
+      ],
+      "additionalItems": {
+        "anyOf": [
+          {"type": "object",
+          "properties": {
+            "area_cycle_duration": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "integer"
+                },
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "description": {"type": "string"},
+                    "unit": {"type": "string"},
+                    "dtype": {"type": "string"},
+                    "teckkey": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }},
+          {}
+        ]
+      }
     }
   }
 }

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -24,11 +24,11 @@
       "type": "string"
     },
     "name": {
-      "description": "Internal shortname of the configuration parameter set. Used to load a configuration JSON file",
+      "description": "Internal shortname of the configuration parameter set. Used to load a configuration JSON file with the 'FloatConfiguration' class.",
       "type": "string"
     },
     "parameters": {
-      "description": "List of configuration parameters",
+      "description": "List of virtual Argo floats configuration parameters",
       "type": "array",
       "oneOf": [
         {

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json",
   "title": "VirtualFleet Argo Float configuration",
   "description": "A set of data documenting a virtual Argo Float configuration to be used in a VirtualFleet simulation",
   "format_version": {

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -58,7 +58,8 @@
             "area_xmax",
             "area_xmin",
             "area_ymax",
-            "area_ymin"
+            "area_ymin",
+            "reco_free_surface_drift",
           ]
         },
         "value": {

--- a/schemas/VF-ArgoFloat-Configuration.json
+++ b/schemas/VF-ArgoFloat-Configuration.json
@@ -59,7 +59,7 @@
             "area_xmin",
             "area_ymax",
             "area_ymin",
-            "reco_free_surface_drift",
+            "reco_free_surface_drift"
           ]
         },
         "value": {

--- a/virtualargofleet/app_parcels.py
+++ b/virtualargofleet/app_parcels.py
@@ -384,15 +384,6 @@ def PeriodicBoundaryConditionKernel(particle, fieldset, time):
         particle_dlast -= fieldset.halo_north - fieldset.halo_south
 
 
-
-def KeepInDomain(particle, fieldset, time):
-    # out of geographical area : here we can delete the particle
-    if particle.state == StatusCode.ErrorOutOfBounds:
-        if fieldset.verbose_events == 1:
-            print("Field warning : Float out of the horizontal geographical domain --> deleted")
-        particle.delete()
-
-
 def KeepInWater(particle, fieldset, time):
     if particle.state == StatusCode.ErrorThroughSurface:
         # Make the float sticks to the surface level
@@ -404,14 +395,25 @@ def KeepInWater(particle, fieldset, time):
         particle.state = StatusCode.Success
 
 
-def KeepInColumn(particle, fieldset, time):
+# def KeepInColumn(particle, fieldset, time):
+#     if particle.state == StatusCode.ErrorOutOfBounds:
+#         # Make the float sticks to the bottom level
+#         # Rq: change in cycle phase is managed by the FloatKernel
+#         # Here, we don't let the float going deeper, and change in particle_ddepth are managed by FloatKernel
+#         # depending on the cycle phase
+#         if particle.depth <= fieldset.vf_bottom:            
+#             if fieldset.verbose_events == 1:
+#                 print(
+#                     "Field warning : Float reached fieldset bottom ! Your fieldset is not deep enough compared to float drift or profiling depths.")
+#             particle.depth = fieldset.vf_bottom
+#             particle.state = StatusCode.Success
+#         else :
+#             # Go throught KeepInDomain
+#             pass 
+
+def KeepInDomain(particle, fieldset, time):
+    # out of geographical area : here we can delete the particle
     if particle.state == StatusCode.ErrorOutOfBounds:
-        # Make the float sticks to the bottom level
-        # Rq: change in cycle phase is managed by the FloatKernel
-        # Here, we don't let the float going deeper, and change in particle_ddepth are managed by FloatKernel
-        # depending on the cycle phase
-        if fieldset.verbose_events == 1:
-            print(
-                "Field warning : Float reached fieldset bottom ! Your fieldset is not deep enough compared to float drift or profiling depths.")
-        particle.depth = fieldset.vf_bottom
-        particle.state = StatusCode.Success
+        if fieldset.verbose_events == 1:            
+            print("Field warning : Float out of the horizontal geographical domain OR interpolation error --> deleted")
+        particle.delete()

--- a/virtualargofleet/assets/FloatConfiguration_default.json
+++ b/virtualargofleet/assets/FloatConfiguration_default.json
@@ -10,8 +10,10 @@
             "meta": {
                 "unit": "hours",
                 "dtype": "float",
-                "techkey": "CONFIG_CycleTime_hours"
-            }
+                "techkey": "CONFIG_CycleTime_hours",
+                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
+            },
+            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
         },
         {
             "name": "life_expectancy",
@@ -20,8 +22,10 @@
             "meta": {
                 "unit": "cycle",
                 "dtype": "int",
-                "techkey": "CONFIG_MaxCycles_NUMBER"
-            }
+                "techkey": "CONFIG_MaxCycles_NUMBER",
+                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
+            },
+            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
         },
         {
             "name": "parking_depth",
@@ -30,8 +34,10 @@
             "meta": {
                 "unit": "m",
                 "dtype": "float",
-                "techkey": "CONFIG_ParkPressure_dbar"
-            }
+                "techkey": "CONFIG_ParkPressure_dbar",
+                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
+            },
+            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
         },
         {
             "name": "profile_depth",
@@ -40,8 +46,10 @@
             "meta": {
                 "unit": "m",
                 "dtype": "float",
-                "techkey": "CONFIG_ProfilePressure_dbar"
-            }
+                "techkey": "CONFIG_ProfilePressure_dbar",
+                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
+            },
+            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
         },
         {
             "name": "vertical_speed",
@@ -50,8 +58,10 @@
             "meta": {
                 "unit": "m/s",
                 "dtype": "float",
-                "techkey": ""
-            }
+                "techkey": "",
+                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
+            },
+            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
         }
     ],
     "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"

--- a/virtualargofleet/assets/FloatConfiguration_default.json
+++ b/virtualargofleet/assets/FloatConfiguration_default.json
@@ -10,10 +10,8 @@
             "meta": {
                 "unit": "hours",
                 "dtype": "float",
-                "techkey": "CONFIG_CycleTime_hours",
-                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
-            },
-            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
+                "techkey": "CONFIG_CycleTime_hours"
+            }
         },
         {
             "name": "life_expectancy",
@@ -22,10 +20,8 @@
             "meta": {
                 "unit": "cycle",
                 "dtype": "int",
-                "techkey": "CONFIG_MaxCycles_NUMBER",
-                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
-            },
-            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
+                "techkey": "CONFIG_MaxCycles_NUMBER"
+            }
         },
         {
             "name": "parking_depth",
@@ -34,10 +30,8 @@
             "meta": {
                 "unit": "m",
                 "dtype": "float",
-                "techkey": "CONFIG_ParkPressure_dbar",
-                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
-            },
-            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
+                "techkey": "CONFIG_ParkPressure_dbar"
+            }
         },
         {
             "name": "profile_depth",
@@ -46,10 +40,8 @@
             "meta": {
                 "unit": "m",
                 "dtype": "float",
-                "techkey": "CONFIG_ProfilePressure_dbar",
-                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
-            },
-            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
+                "techkey": "CONFIG_ProfilePressure_dbar"
+            }
         },
         {
             "name": "vertical_speed",
@@ -58,10 +50,8 @@
             "meta": {
                 "unit": "m/s",
                 "dtype": "float",
-                "techkey": "",
-                "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#parameter_metadata"
-            },
-            "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json#required_parameter"
+                "techkey": ""
+            }
         }
     ],
     "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"

--- a/virtualargofleet/assets/FloatConfiguration_default.json
+++ b/virtualargofleet/assets/FloatConfiguration_default.json
@@ -1,5 +1,5 @@
 {
-    "created": "2024-03-06T15:54:38.818728+00:00",
+    "created": "2024-03-07T08:44:43.560904+00:00",
     "version": "2.0",
     "name": "default",
     "parameters": [
@@ -54,5 +54,5 @@
             }
         }
     ],
-    "$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
+    "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
 }

--- a/virtualargofleet/assets/FloatConfiguration_default_v1.json
+++ b/virtualargofleet/assets/FloatConfiguration_default_v1.json
@@ -1,58 +1,52 @@
 {
-    "created": "2024-03-06T15:54:38.818728+00:00",
-    "version": "2.0",
     "name": "default",
-    "parameters": [
-        {
-            "name": "cycle_duration",
+    "version": "1.0",
+    "created": "20221212151119",
+    "data": {
+        "cycle_duration": {
             "value": 240.0,
-            "description": "Maximum length of float complete cycle",
             "meta": {
+                "description": "Maximum length of float complete cycle",
                 "unit": "hours",
                 "dtype": "float",
                 "techkey": "CONFIG_CycleTime_hours"
             }
         },
-        {
-            "name": "life_expectancy",
+        "life_expectancy": {
             "value": 200,
-            "description": "Maximum number of completed cycle",
             "meta": {
+                "description": "Maximum number of completed cycle",
                 "unit": "cycle",
                 "dtype": "int",
                 "techkey": "CONFIG_MaxCycles_NUMBER"
             }
         },
-        {
-            "name": "parking_depth",
+        "parking_depth": {
             "value": 1000.0,
-            "description": "Drifting depth",
             "meta": {
+                "description": "Drifting depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ParkPressure_dbar"
             }
         },
-        {
-            "name": "profile_depth",
+        "profile_depth": {
             "value": 2000.0,
-            "description": "Maximum profile depth",
             "meta": {
+                "description": "Maximum profile depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ProfilePressure_dbar"
             }
         },
-        {
-            "name": "vertical_speed",
+        "vertical_speed": {
             "value": 0.09,
-            "description": "Vertical profiling speed",
             "meta": {
+                "description": "Vertical profiling speed",
                 "unit": "m/s",
                 "dtype": "float",
                 "techkey": ""
             }
         }
-    ],
-    "$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
+    }
 }

--- a/virtualargofleet/assets/FloatConfiguration_gulf_stream.json
+++ b/virtualargofleet/assets/FloatConfiguration_gulf_stream.json
@@ -1,5 +1,5 @@
 {
-    "created": "2024-03-06T16:05:40.238562+00:00",
+    "created": "2024-03-07T08:44:44.033446+00:00",
     "version": "2.0",
     "name": "gulf-stream",
     "parameters": [
@@ -114,5 +114,5 @@
             }
         }
     ],
-    "$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
+    "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
 }

--- a/virtualargofleet/assets/FloatConfiguration_gulf_stream_v1.json
+++ b/virtualargofleet/assets/FloatConfiguration_gulf_stream_v1.json
@@ -1,118 +1,106 @@
 {
-    "created": "2024-03-06T16:05:40.238562+00:00",
-    "version": "2.0",
     "name": "gulf-stream",
-    "parameters": [
-        {
-            "name": "area_cycle_duration",
+    "version": "1.0",
+    "created": "20221212151158",
+    "data": {
+        "area_cycle_duration": {
             "value": 120.0,
-            "description": "Maximum length of float complete cycle in AREA",
             "meta": {
+                "description": "Maximum length of float complete cycle in AREA",
                 "unit": "hours",
                 "dtype": "float",
                 "techkey": "CONFIG_CycleTime_hours"
             }
         },
-        {
-            "name": "area_parking_depth",
+        "area_parking_depth": {
             "value": 1000.0,
-            "description": "Drifting depth in AREA",
             "meta": {
+                "description": "Drifting depth in AREA",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ParkPressure_dbar"
             }
         },
-        {
-            "name": "area_xmax",
+        "area_xmax": {
             "value": -48.0,
-            "description": "AREA Eastern bound",
             "meta": {
+                "description": "AREA Eastern bound",
                 "unit": "deg_longitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "area_xmin",
+        "area_xmin": {
             "value": -75.0,
-            "description": "AREA Western bound",
             "meta": {
+                "description": "AREA Western bound",
                 "unit": "deg_longitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "area_ymax",
+        "area_ymax": {
             "value": 45.5,
-            "description": "AREA Northern bound",
             "meta": {
+                "description": "AREA Northern bound",
                 "unit": "deg_latitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "area_ymin",
+        "area_ymin": {
             "value": 33.0,
-            "description": "AREA Southern bound",
             "meta": {
+                "description": "AREA Southern bound",
                 "unit": "deg_latitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "cycle_duration",
+        "cycle_duration": {
             "value": 240.0,
-            "description": "Maximum length of float complete cycle",
             "meta": {
+                "description": "Maximum length of float complete cycle",
                 "unit": "hours",
                 "dtype": "float",
                 "techkey": "CONFIG_CycleTime_hours"
             }
         },
-        {
-            "name": "life_expectancy",
+        "life_expectancy": {
             "value": 200,
-            "description": "Maximum number of completed cycle",
             "meta": {
+                "description": "Maximum number of completed cycle",
                 "unit": "cycle",
                 "dtype": "int",
                 "techkey": "CONFIG_MaxCycles_NUMBER"
             }
         },
-        {
-            "name": "parking_depth",
+        "parking_depth": {
             "value": 1000.0,
-            "description": "Drifting depth",
             "meta": {
+                "description": "Drifting depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ParkPressure_dbar"
             }
         },
-        {
-            "name": "profile_depth",
+        "profile_depth": {
             "value": 2000.0,
-            "description": "Maximum profile depth",
             "meta": {
+                "description": "Maximum profile depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ProfilePressure_dbar"
             }
         },
-        {
-            "name": "vertical_speed",
+        "vertical_speed": {
             "value": 0.09,
-            "description": "Vertical profiling speed",
             "meta": {
+                "description": "Vertical profiling speed",
                 "unit": "m/s",
                 "dtype": "float",
                 "techkey": ""
             }
         }
-    ],
-    "$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
+    }
 }

--- a/virtualargofleet/assets/FloatConfiguration_local_change.json
+++ b/virtualargofleet/assets/FloatConfiguration_local_change.json
@@ -1,106 +1,118 @@
 {
+    "created": "2024-03-06T16:05:31.448953+00:00",
+    "version": "2.0",
     "name": "local-change",
-    "version": "1.0",
-    "created": "20221212151138",
-    "data": {
-        "area_cycle_duration": {
+    "parameters": [
+        {
+            "name": "area_cycle_duration",
             "value": 120.0,
+            "description": "Maximum length of float complete cycle in AREA",
             "meta": {
-                "description": "Maximum length of float complete cycle in AREA",
                 "unit": "hours",
                 "dtype": "float",
                 "techkey": "CONFIG_CycleTime_hours"
             }
         },
-        "area_parking_depth": {
+        {
+            "name": "area_parking_depth",
             "value": 1000.0,
+            "description": "Drifting depth in AREA",
             "meta": {
-                "description": "Drifting depth in AREA",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ParkPressure_dbar"
             }
         },
-        "area_xmax": {
+        {
+            "name": "area_xmax",
             "value": -48.0,
+            "description": "AREA Eastern bound",
             "meta": {
-                "description": "AREA Eastern bound",
                 "unit": "deg_longitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        "area_xmin": {
+        {
+            "name": "area_xmin",
             "value": -75.0,
+            "description": "AREA Western bound",
             "meta": {
-                "description": "AREA Western bound",
                 "unit": "deg_longitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        "area_ymax": {
+        {
+            "name": "area_ymax",
             "value": 45.5,
+            "description": "AREA Northern bound",
             "meta": {
-                "description": "AREA Northern bound",
                 "unit": "deg_latitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        "area_ymin": {
+        {
+            "name": "area_ymin",
             "value": 33.0,
+            "description": "AREA Southern bound",
             "meta": {
-                "description": "AREA Southern bound",
                 "unit": "deg_latitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        "cycle_duration": {
+        {
+            "name": "cycle_duration",
             "value": 240.0,
+            "description": "Maximum length of float complete cycle",
             "meta": {
-                "description": "Maximum length of float complete cycle",
                 "unit": "hours",
                 "dtype": "float",
                 "techkey": "CONFIG_CycleTime_hours"
             }
         },
-        "life_expectancy": {
+        {
+            "name": "life_expectancy",
             "value": 200,
+            "description": "Maximum number of completed cycle",
             "meta": {
-                "description": "Maximum number of completed cycle",
                 "unit": "cycle",
                 "dtype": "int",
                 "techkey": "CONFIG_MaxCycles_NUMBER"
             }
         },
-        "parking_depth": {
+        {
+            "name": "parking_depth",
             "value": 1000.0,
+            "description": "Drifting depth",
             "meta": {
-                "description": "Drifting depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ParkPressure_dbar"
             }
         },
-        "profile_depth": {
+        {
+            "name": "profile_depth",
             "value": 2000.0,
+            "description": "Maximum profile depth",
             "meta": {
-                "description": "Maximum profile depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ProfilePressure_dbar"
             }
         },
-        "vertical_speed": {
+        {
+            "name": "vertical_speed",
             "value": 0.09,
+            "description": "Vertical profiling speed",
             "meta": {
-                "description": "Vertical profiling speed",
                 "unit": "m/s",
                 "dtype": "float",
                 "techkey": ""
             }
         }
-    }
+    ],
+    "$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
 }

--- a/virtualargofleet/assets/FloatConfiguration_local_change.json
+++ b/virtualargofleet/assets/FloatConfiguration_local_change.json
@@ -1,5 +1,5 @@
 {
-    "created": "2024-03-06T16:05:31.448953+00:00",
+    "created": "2024-03-07T08:44:43.800205+00:00",
     "version": "2.0",
     "name": "local-change",
     "parameters": [
@@ -114,5 +114,5 @@
             }
         }
     ],
-    "$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
+    "$schema": "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
 }

--- a/virtualargofleet/assets/FloatConfiguration_local_change_v1.json
+++ b/virtualargofleet/assets/FloatConfiguration_local_change_v1.json
@@ -1,118 +1,106 @@
 {
-    "created": "2024-03-06T16:05:40.238562+00:00",
-    "version": "2.0",
-    "name": "gulf-stream",
-    "parameters": [
-        {
-            "name": "area_cycle_duration",
+    "name": "local-change",
+    "version": "1.0",
+    "created": "20221212151138",
+    "data": {
+        "area_cycle_duration": {
             "value": 120.0,
-            "description": "Maximum length of float complete cycle in AREA",
             "meta": {
+                "description": "Maximum length of float complete cycle in AREA",
                 "unit": "hours",
                 "dtype": "float",
                 "techkey": "CONFIG_CycleTime_hours"
             }
         },
-        {
-            "name": "area_parking_depth",
+        "area_parking_depth": {
             "value": 1000.0,
-            "description": "Drifting depth in AREA",
             "meta": {
+                "description": "Drifting depth in AREA",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ParkPressure_dbar"
             }
         },
-        {
-            "name": "area_xmax",
+        "area_xmax": {
             "value": -48.0,
-            "description": "AREA Eastern bound",
             "meta": {
+                "description": "AREA Eastern bound",
                 "unit": "deg_longitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "area_xmin",
+        "area_xmin": {
             "value": -75.0,
-            "description": "AREA Western bound",
             "meta": {
+                "description": "AREA Western bound",
                 "unit": "deg_longitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "area_ymax",
+        "area_ymax": {
             "value": 45.5,
-            "description": "AREA Northern bound",
             "meta": {
+                "description": "AREA Northern bound",
                 "unit": "deg_latitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "area_ymin",
+        "area_ymin": {
             "value": 33.0,
-            "description": "AREA Southern bound",
             "meta": {
+                "description": "AREA Southern bound",
                 "unit": "deg_latitude",
                 "dtype": "float",
                 "techkey": ""
             }
         },
-        {
-            "name": "cycle_duration",
+        "cycle_duration": {
             "value": 240.0,
-            "description": "Maximum length of float complete cycle",
             "meta": {
+                "description": "Maximum length of float complete cycle",
                 "unit": "hours",
                 "dtype": "float",
                 "techkey": "CONFIG_CycleTime_hours"
             }
         },
-        {
-            "name": "life_expectancy",
+        "life_expectancy": {
             "value": 200,
-            "description": "Maximum number of completed cycle",
             "meta": {
+                "description": "Maximum number of completed cycle",
                 "unit": "cycle",
                 "dtype": "int",
                 "techkey": "CONFIG_MaxCycles_NUMBER"
             }
         },
-        {
-            "name": "parking_depth",
+        "parking_depth": {
             "value": 1000.0,
-            "description": "Drifting depth",
             "meta": {
+                "description": "Drifting depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ParkPressure_dbar"
             }
         },
-        {
-            "name": "profile_depth",
+        "profile_depth": {
             "value": 2000.0,
-            "description": "Maximum profile depth",
             "meta": {
+                "description": "Maximum profile depth",
                 "unit": "m",
                 "dtype": "float",
                 "techkey": "CONFIG_ProfilePressure_dbar"
             }
         },
-        {
-            "name": "vertical_speed",
+        "vertical_speed": {
             "value": 0.09,
-            "description": "Vertical profiling speed",
             "meta": {
+                "description": "Vertical profiling speed",
                 "unit": "m/s",
                 "dtype": "float",
                 "techkey": ""
             }
         }
-    ],
-    "$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json"
+    }
 }

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -24,6 +24,8 @@ path2data = pkg_resources.resource_filename("virtualargofleet", "assets/")
 
 
 class VFschema:
+    """A base class to export json files following a schema"""
+    schema_root: str = "https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas"
 
     def __init__(self, **kwargs):
         for key in self.required:
@@ -71,8 +73,7 @@ class VFschema:
     def to_json(self, fp=None):
         jsdata = self.__dict__
         if hasattr(self, 'schema'):
-            jsdata.update({"$schema": "https://raw.githubusercontent.com/euroargodev/json-schemas-FloatConfiguration/schemas/%s.json" % getattr(
-                self, 'schema')})
+            jsdata.update({"$schema": "%s/%s.json" % (self.schema_root, getattr(self, 'schema'))})
         if fp is None:
             return json.dumps(jsdata, indent=4, cls=self.JSONEncoder)
         else:
@@ -80,6 +81,7 @@ class VFschema:
 
 
 class VFschema_meta(VFschema):
+    """JSON schema handler for meta-data of a :class:`ConfigParam` instance"""
     unit: str
     dtype: str
     techkey: str
@@ -94,6 +96,7 @@ class VFschema_meta(VFschema):
 
 
 class VFschema_parameter(VFschema):
+    """JSON schema handler for a :class:`ConfigParam` instance"""
     name: str
     value: Union[str, float]
     meta: VFschema_meta
@@ -113,6 +116,7 @@ class VFschema_parameter(VFschema):
 
 
 class VFschema_configuration(VFschema):
+    """JSON schema handler for a :class:`FloatConfiguration` instance"""
     version: str
     name: str
     parameters: List[VFschema_parameter]

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -194,7 +194,7 @@ class ConfigParam:
         })
 
     def to_json(self, *args, **kwargs):
-        """Return a dictionary serialisable in json"""
+        """Return a dictionary serialisable in json or write to file"""
         return self.json_schema.to_json(*args, **kwargs)
 
     value = property(get_value, set_value)
@@ -382,7 +382,7 @@ class FloatConfiguration:
         })
 
     def to_json(self, *args, **kwargs):
-        """Return a dictionary serialisable in json"""
+        """Return a dictionary serialisable in json or write to file"""
         return self.json_schema.to_json(*args, **kwargs)
 
 

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -73,7 +73,7 @@ class VFschema:
             value = getattr(self, key)
             d.update({key: value})
         return d
-    
+
     def to_json(self, fp: Union[str, Path, TextIO] = None, indent=4):
         """Save to JSON file or return a JSON string that can be loaded with json.loads()"""
         jsdata = self.__dict__

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -86,13 +86,13 @@ class VFschema:
     @staticmethod
     def validate(data, schema) -> Union[bool, List]:
         # Read schema and create validator:
-        schema = json.loads(schema)
+        schema = json.loads(Path(schema).read_text())
         res = Resource.from_contents(schema)
         registry = Registry(retrieve = res)
         validator = jsonschema.Draft202012Validator(schema, registry=registry)
 
         # Read data and validate against schema:
-        data = json.loads(data)
+        data = json.loads(Path(data).read_text())
         # return validator.validate(data)
         try:
             validator.validate(data)
@@ -287,8 +287,9 @@ class FloatConfiguration:
                 raise ValueError("This file is not with format 2.0 version: '%s'" % js['version'])
 
             # Validate json against schema:
-            json_schema = Path(os.path.join(path2schemas, 'VF-ArgoFloat-Configuration.json')).read_text()
-            errors = VFschema_configuration.validate(Path(name).read_text(), json_schema)
+            # json_schema = Path(os.path.join(path2schemas, 'VF-ArgoFloat-Configuration.json')).read_text()
+            json_schema = os.path.join(path2schemas, 'VF-ArgoFloat-Configuration.json')
+            errors = VFschema_configuration.validate(name, json_schema)
             if isinstance(errors, list):
                 log.debug(list)
                 raise jsonschema.exceptions.ValidationError("This Float configuration file is not valid against format version 2.0\n%s" % str(errors))

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -211,6 +211,9 @@ class FloatConfiguration:
 
         If no file name is provided, just return the configuration as a json structure
 
+        Produces a json file following the public schema documented here:
+        https://raw.githubusercontent.com/euroargodev/VirtualFleet/schemas/VF-schema-ArgoFloatConfig.json
+
         Parameters
         ----------
         file_name: str, default:None, optional

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -311,6 +311,7 @@ class FloatConfiguration:
             with open(name, "r") as f:
                 js = json.load(f)
             if js['version'] == "1.0":
+                warnings.warn("There is a newer json file format '2.0' for Argo float configuration available, please re-save this configuration, it will automatically be updated to the new format.")
                 return load_from_json_v1(name)
             elif js['version'] == "2.0":
                 return load_from_json_v2(name)

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -358,9 +358,9 @@ class FloatConfiguration:
             # Over-write known parameters:
             for code in di.keys():
                 if code in df:
-                    self.update(di[code].iloc[0], df[code].iloc[0])
+                    self.update(di[code], df[code].iloc[0])
                     if code == 'CONFIG_AscentSpeed_mm/s':
-                        self.update(di[code].iloc[0], df[code].iloc[0]/1000)  # Convert mm/s to m/s
+                        self.update(di[code], df[code].iloc[0]/1000)  # Convert mm/s to m/s
                 else:
                     msg = "%s not found for this profile, fall back on default value: %s" % \
                           (code, self._params_dict[di[code]])

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -217,6 +217,7 @@ class ConfigParam:
     def set_value(self, value):
         if self.meta['dtype'] != '':
             try:
+                print(self.key)
                 value = self.meta['dtype'](value)
             except ValueError:
                 raise ValueError("Cannot cast '%s' value as expected %s" % (self.key, self.str_val(self.meta['dtype'])))
@@ -358,9 +359,9 @@ class FloatConfiguration:
             # Over-write known parameters:
             for code in di.keys():
                 if code in df:
-                    self.update(di[code], df[code])
+                    self.update(di[code].iloc[0], df[code].iloc[0])
                     if code == 'CONFIG_AscentSpeed_mm/s':
-                        self.update(di[code], df[code]/1000)  # Convert mm/s to m/s
+                        self.update(di[code].iloc[0], df[code].iloc[0]/1000)  # Convert mm/s to m/s
                 else:
                     msg = "%s not found for this profile, fall back on default value: %s" % \
                           (code, self._params_dict[di[code]])

--- a/virtualargofleet/utilities.py
+++ b/virtualargofleet/utilities.py
@@ -217,7 +217,6 @@ class ConfigParam:
     def set_value(self, value):
         if self.meta['dtype'] != '':
             try:
-                print(self.key)
                 value = self.meta['dtype'](value)
             except ValueError:
                 raise ValueError("Cannot cast '%s' value as expected %s" % (self.key, self.str_val(self.meta['dtype'])))

--- a/virtualargofleet/velocity_helpers.py
+++ b/virtualargofleet/velocity_helpers.py
@@ -165,7 +165,7 @@ class VelocityField_CUSTOM(VelocityField):
         self.add_mask()
 
 
-def VelocityFieldFacade(model: str = 'GLOBAL_ANALYSIS_FORECAST_PHY_001_024', *args, **kwargs):
+def VelocityFieldFacade(model: str = 'GLOBAL_ANALYSIS_FORECAST_PHY_001_024', *args: object, **kwargs: object) -> object:
     """Function to return a :class:`VelocityField` instance for known products
 
     Note that you can provide a :class:`VelocityField` or :attr:`VelocityField.fieldset`

--- a/virtualargofleet/velocity_helpers.py
+++ b/virtualargofleet/velocity_helpers.py
@@ -17,7 +17,7 @@ class VelocityField(ABC):
     """Class prototype to manage a Virtual Fleet velocity field
 
     This prototype provides useful methods to prepare a :class:`parcels.fieldset.FieldSet` for a VirtualFleet simulation.
-    A :class:`VelocityField` instance can be passed directly to a :class:`.VirtualFleet` instance.
+    A :class:`VelocityField` instance can be passed directly to a :class:`VirtualFleet` instance.
 
     You can use the :meth:`Velocity` function to instantiate such a class for known products.
 

--- a/virtualargofleet/virtualargofleet.py
+++ b/virtualargofleet/virtualargofleet.py
@@ -19,7 +19,7 @@ from .app_parcels import (
     ArgoFloatKernel,
     ArgoFloatKernel_exp,
     PeriodicBoundaryConditionKernel,
-    KeepInDomain, KeepInWater, KeepInColumn,
+    KeepInDomain, KeepInWater #, KeepInColumn,
 )
 from .velocity_helpers import VelocityField
 from .utilities import SimulationSet, FloatConfiguration
@@ -209,7 +209,7 @@ class VirtualFleet:
         if self._isglobal:
             K += self._parcels['ParticleSet'].Kernel(PeriodicBoundaryConditionKernel)
         K += self._parcels['ParticleSet'].Kernel(KeepInWater)
-        K += self._parcels['ParticleSet'].Kernel(KeepInColumn)
+        #K += self._parcels['ParticleSet'].Kernel(KeepInColumn)
         K += self._parcels['ParticleSet'].Kernel(KeepInDomain)
 
         self._parcels['kernels'] = K


### PR DESCRIPTION
Closes #28 
Make VirtualFleet compatible with https://github.com/euroargodev/VirtualFleet_recovery/pull/14

This PR introduces a new JSON format version "2.0" for ``FloatConfiguration`` export to json to be used by VirtualFleet:

- [x] Made the ``FloatConfiguration`` compatible with both versions of the format
- [x] ``FloatConfiguration`` now only export to format version 2 
- [x] Published [a JSON schema](https://raw.githubusercontent.com/euroargodev/VirtualFleet/json-schemas-FloatConfiguration/schemas/VF-ArgoFloat-Configuration.json) to document the ``FloatConfiguration`` export to json files. The schema is not exactly as I wished (I didn't managed to enforce the check for a list of required parameters, check is limited to the name of parameters)
- [x] Check for format compliance when loading a configuration file with ``FloatConfiguration``

This PR implies NO changes from the user point of view